### PR TITLE
adoc: Fix ARM Release Semihosting specification URL

### DIFF
--- a/riscv-semihosting-spec.adoc
+++ b/riscv-semihosting-spec.adoc
@@ -36,7 +36,7 @@ mechanism to minimize the development effort required. The RISC-V
 semihosting is based on the "Semihosting for AArch32 and AArch64:
 Release 2.0" specification available here:
 
-	https://static.docs.arm.com/100863/0200/semihosting.pdf
+	https://developer.arm.com/documentation/100863/0200/
 
 Referring to Chapter Three in that document, the following extensions
 are needed to provide RISC-V support.


### PR DESCRIPTION
The old site seems to be gone.  The new site hosts both version 2.0
and the newer version 2019Q4 in both PDF and HTML formats.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>