### PR TITLE
Fix the broken URL of Arm semihosting spec

### DIFF
--- a/riscv-semihosting-spec.adoc
+++ b/riscv-semihosting-spec.adoc
@@ -33,10 +33,10 @@ in that target environment.
 
 RISC-V semihosting borrows from the design of the ARM semihosting
 mechanism to minimize the development effort required. The RISC-V
-semihosting is based on the "Semihosting for AArch32 and AArch64:
-Release 2.0" specification available here:
+semihosting is based on the "Semihosting for AArch32 and AArch64"
+specification available here:
 
-	https://static.docs.arm.com/100863/0200/semihosting.pdf
+	https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst
 
 Referring to Chapter Three in that document, the following extensions
 are needed to provide RISC-V support.


### PR DESCRIPTION
Resolves: https://github.com/riscv/riscv-semihosting-spec/issues/2
Signed-off-by: Bin Meng <bmeng.cn@gmail.com>